### PR TITLE
Get wlanX from iwinfo outoput instead relying on radioX naming

### DIFF
--- a/files/wwanHotspot.sh
+++ b/files/wwanHotspot.sh
@@ -170,8 +170,8 @@ LoadConfig() {
 		if [ "${m}" = "sta" ]; then
 			WIfaceSTA=${i}
 			d="$(uci -q get wireless.@wifi-iface[${i}].device)"
-			WIface="wlan$(echo "${d}" | \
-				sed -nre '/.*([[:digit:]]+)$/ s//\1/p')"
+			WIface="wlan$(iwinfo $d info | grep 'PHY name' | \
+                                sed -nre '/.*phy([[:digit:]])$/ s//\1/p')"
 			break
 		fi
 	done


### PR DESCRIPTION
E.g. I'd like to name my two radios radio2g and radio5g